### PR TITLE
specify python2 in shebang

### DIFF
--- a/api/xsshunter.py
+++ b/api/xsshunter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 @author: mandatory, moloch
 Copyright 2016

--- a/auto-setup.py
+++ b/auto-setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 @author: mandatory, moloch
 Copyright 2016

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import argparse


### PR DESCRIPTION
Small convenience fix. On the majority of Linux distros, python3 is now the default which will cause conflicts if `env python` vs `env python2` is specified the shebang.

`for pyfile in $(find . -name '*.py'); do sed -i -e 's;/usr/bin/env python;/usr/bin/env python2; $pyfile'; done`